### PR TITLE
Update DNSimple

### DIFF
--- a/_data/2fasites.yml
+++ b/_data/2fasites.yml
@@ -3117,6 +3117,7 @@ websites:
     img: dnsimple.png
     tfa:
       - totp
+      - hardware
     doc: https://support.dnsimple.com/articles/two-factor-authentication/
 
   - name: Domains4Bitcoins.com


### PR DESCRIPTION
DNSimple now support hardware keys via webauthn.
See https://blog.dnsimple.com/2022/06/support-webauthn-api/
